### PR TITLE
DIM-28 Add foreignKeyTableName to liquibase constraints

### DIFF
--- a/api/src/main/resources/liquibase-linktables-schema.xml
+++ b/api/src/main/resources/liquibase-linktables-schema.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-         
-	
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
 	<changeSet id="dim-categorycombo categoryoption" author="maurya">
 		<preConditions onFail="MARK_RAN">
 			<not>
@@ -147,7 +146,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_catcombo_combooption">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="catcombo_combooption_categorycombo" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_catcombo_combooption" foreignKeyName="catcombo_combooption_categorycombo" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="catcombo_id" baseTableName="dim_catcombo_combooption" constraintName="catcombo_combooption_categorycombo" referencedColumnNames="id" referencedTableName="dim_categorycombo"/>
@@ -157,7 +156,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_catcombo_optionset">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="catcombo_optionset_categorycombo" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_catcombo_optionset" foreignKeyName="catcombo_optionset_categorycombo" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="catcombo_id" baseTableName="dim_catcombo_optionset" constraintName="catcombo_optionset_categorycombo" referencedColumnNames="id" referencedTableName="dim_categorycombo"/>
@@ -167,7 +166,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_categoryoption_option">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="categoryoption_option_categoryoption" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_categoryoption_option" foreignKeyName="categoryoption_option_categoryoption" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="categoryoption_id" baseTableName="dim_categoryoption_option" constraintName="categoryoption_option_categoryoption" referencedColumnNames="id" referencedTableName="dim_categoryoption"/>
@@ -177,7 +176,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_optionset_option">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="optionset_option_optionset" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_optionset_option" foreignKeyName="optionset_option_optionset" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="optionset_id" baseTableName="dim_optionset_option" constraintName="optionset_option_optionset" referencedColumnNames="id" referencedTableName="dim_optionset"/>
@@ -187,7 +186,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_orgunit_location">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="orgunit_location_orgunit" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_orgunit_location" foreignKeyName="orgunit_location_orgunit" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="orgunit_id" baseTableName="dim_orgunit_location" constraintName="orgunit_location_orgunit" referencedColumnNames="id" referencedTableName="dim_orgunit"/>
@@ -197,7 +196,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_reporttemplate_dataelement">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="reporttemplate_dataelement_reporttemplate" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_reporttemplate_dataelement" foreignKeyName="reporttemplate_dataelement_reporttemplate" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="reporttemplate_id" baseTableName="dim_reporttemplate_dataelement" constraintName="reporttemplate_dataelement_reporttemplate" referencedColumnNames="id" referencedTableName="dim_reporttemplate"/>

--- a/api/src/main/resources/liquibase-maintables-schema.xml
+++ b/api/src/main/resources/liquibase-maintables-schema.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
          
 	<changeSet id="dim-IntegrationServer" author="maurya">
 		<preConditions onFail="MARK_RAN">
@@ -279,7 +279,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_orgunit">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="orgunit_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_orgunit" foreignKeyName="orgunit_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_orgunit" constraintName="orgunit_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -289,7 +289,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_dataelement">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="dataelement_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_dataelement" foreignKeyName="dataelement_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_dataelement" constraintName="dataelement_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -300,7 +300,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_categorycombo">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="categorycombo_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_categorycombo" foreignKeyName="categorycombo_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_categorycombo" constraintName="categorycombo_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -309,7 +309,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_categoryoption">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="categoryoption_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_categoryoption" foreignKeyName="categoryoption_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_categoryoption" constraintName="categoryoption_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -318,7 +318,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_optionset">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="optionset_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_optionset" foreignKeyName="optionset_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_optionset" constraintName="optionset_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -327,7 +327,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_option">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="option_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_option" foreignKeyName="option_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_option" constraintName="option_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -336,7 +336,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_reporttemplate">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="reporttemplate_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_reporttemplate" foreignKeyName="reporttemplate_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_reporttemplate" constraintName="reporttemplate_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>
@@ -345,7 +345,7 @@
 	<changeSet author="maurya" id="foreign_key_constraints-dim_datavaluetemplate">
 		<preConditions onFail="MARK_RAN">
 			<not>
-				<foreignKeyConstraintExists foreignKeyName="datavaluetemplate_serverid" />
+				<foreignKeyConstraintExists foreignKeyTableName="dim_datavaluetemplate" foreignKeyName="datavaluetemplate_serverid" />
 			</not>
 		</preConditions>
 		<addForeignKeyConstraint baseColumnNames="server_id" baseTableName="dim_datavaluetemplate" constraintName="datavaluetemplate_serverid" referencedColumnNames="id" referencedTableName="dim_integrationserver"/>

--- a/api/src/main/resources/liquibase-minimum-metadata.xml
+++ b/api/src/main/resources/liquibase-minimum-metadata.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     
 <!--     Adding demo dhis server -->
     <changeSet author="maurya" id="demo integrationserver">

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
 	<!-- Updates OpenMRS as required for Integration Adds module specific main tables 
 		or updates them if a new version is installed -->


### PR DESCRIPTION
See [XFRM-216
](https://issues.openmrs.org/browse/DIM-28)

New versions of liquibase requrire the foreignKeyTableName attribute to be set for any foreignKeyConstraintExists tags. This updates the liquibase xml. It also updates the xsd version from 1.9 to 2.0 as 1.9 does not have this attribute.